### PR TITLE
edit: requestAnimationFrame으로 렌더링 직전에 선택 순서에 대한 검증 로직 작성

### DIFF
--- a/src/features/Route/components/RoutePlace.tsx
+++ b/src/features/Route/components/RoutePlace.tsx
@@ -122,22 +122,16 @@ export default function RoutePlace() {
   }
 
   const requestIdRef = useRef(0) // 요청 번호 발급기
-  const latestRequestIdRef = useRef(1) // 마지막 요청 번호
-
-  function validateLastRequest(requestId: number) {
-    if (requestId < latestRequestIdRef.current) return false
-
-    latestRequestIdRef.current = requestId
-    return true
-  }
+  const latestRequestIdRef = useRef(0) // 마지막 요청 번호
 
   function drawMarker(lat: number, lon: number) {
     const requestId = ++requestIdRef.current
 
+    latestRequestIdRef.current = requestId
     if (!validatePath(prevPath, lat, lon)) return
 
     requestAnimationFrame(() => {
-      if (!validateLastRequest(requestId)) return
+      if (requestId !== latestRequestIdRef.current) return
 
       const map = onLoadMarkerMap({ x: lat, y: lon })
       goalMarker(map, { x: lon, y: lat })


### PR DESCRIPTION
연속적인 렌더링으로 인해 버그 발생을 방지하기 위해

티켓이라는 시스템의 로직 도입

클릭 할 때마다 티켓이 발행되고

requestAnimationFrame 이 콜백을 통해 마지막으로 발행된 티켓을 검증하여 한 번만 렌더링 하는 과정을 거침
( requestAnimationFrame은 렌더링 직전에 호출되는 콜백이다)